### PR TITLE
Automatically trim outputs greater than the width

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,10 +12,11 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/r-lib/progress#readme
 BugReports: https://github.com/r-lib/progress/issues
-Imports:
+Imports: 
     hms,
     prettyunits,
-    R6
+    R6,
+    crayon
 Suggests:
     testthat
 RoxygenNote: 6.0.1.9000

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,8 @@
 
 export(progress_bar)
 importFrom(R6,R6Class)
+importFrom(crayon,col_nchar)
+importFrom(crayon,col_substr)
 importFrom(hms,as.hms)
 importFrom(prettyunits,pretty_bytes)
 importFrom(prettyunits,vague_dt)

--- a/R/progress.R
+++ b/R/progress.R
@@ -289,6 +289,7 @@ pb_ratio <- function(self, private) {
 }
 
 #' @importFrom hms as.hms
+#' @importFrom crayon col_nchar col_substr
 
 pb_render <- function(self, private, tokens) {
 
@@ -367,7 +368,7 @@ pb_render <- function(self, private, tokens) {
   }
 
   if (private$has_token["bar"]) {
-    bar_width <- nchar(sub(str, pattern = ":bar", replacement = ""))
+    bar_width <- col_nchar(sub(str, pattern = ":bar", replacement = ""))
     bar_width <- private$width - bar_width
     bar_width <- max(0, bar_width)
 
@@ -381,8 +382,12 @@ pb_render <- function(self, private, tokens) {
     str <- sub(":bar", paste0(complete, incomplete), str)
   }
 
+  if (col_nchar(str) > private$width) {
+    str <- paste0(col_substr(str, 1, private$width - 3), "...")
+  }
+
   if (private$last_draw != str) {
-    if (nchar(private$last_draw) > nchar(str)) {
+    if (col_nchar(private$last_draw) > col_nchar(str)) {
       clear_line(private$stream, private$width)
     }
     cursor_to_start(private$stream)
@@ -406,6 +411,10 @@ pb_update <- function(self, private, ratio, tokens) {
 pb_message <- function(self, private, msg) {
   assert_character(msg)
   stopifnot(!private$finished)
+
+  if (col_nchar(msg) > private$width) {
+    msg <- paste0(col_substr(msg, 1, private$width - 3), "...")
+  }
 
   if (!private$supported) {
     cat(msg, sep = "\n", file = private$stream)

--- a/R/progress.R
+++ b/R/progress.R
@@ -164,8 +164,10 @@ progress_bar <- R6Class("progress_bar",
     },
     tick = function(len = 1, tokens = list()) {
       pb_tick(self, private, len, tokens) },
-    update = function(ratio, tokens = list()) { 
-      pb_update(self, private, ratio, tokens) }
+    update = function(ratio, tokens = list()) {
+      pb_update(self, private, ratio, tokens) },
+    message = function(msg) {
+      pb_message(self, private, msg) }
   ),
 
   private = list(
@@ -187,6 +189,7 @@ progress_bar <- R6Class("progress_bar",
     ),
     callback = NULL,
     clear = NULL,
+    finished = FALSE,
     show_after = NULL,
     last_draw = "",
 
@@ -397,7 +400,21 @@ pb_update <- function(self, private, ratio, tokens) {
   self$tick(goal - private$current, tokens)
 }
 
+pb_message <- function(self, private, msg) {
+  if (!private$supported) {
+    cat(msg, sep = "\n", file = private$stream)
+  } else {
+    clear_line(private$stream, private$width)
+    cursor_to_start(private$stream)
+    cat(msg, sep = "\n", file = private$stream)
+    if (!private$finished) {
+      cat(private$last_draw, file = private$stream)
+    }
+  }
+}
+
 pb_terminate <- function(self, private) {
+  private$finished <- TRUE
   if (!private$supported || !private$toupdate) return(invisible())
   if (private$clear) {
     clear_line(private$stream, private$width)

--- a/R/progress.R
+++ b/R/progress.R
@@ -251,6 +251,7 @@ pb_tick <- function(self, private, len, tokens) {
 
   assert_scalar(len)
   assert_named_or_empty_list(tokens)
+  stopifnot(!private$finished)
 
   if (private$first) {
     private$first <- FALSE
@@ -396,11 +397,16 @@ pb_render <- function(self, private, tokens) {
 
 pb_update <- function(self, private, ratio, tokens) {
   assert_ratio(ratio)
+  stopifnot(!private$finished)
+
   goal <- floor(ratio * private$total)
   self$tick(goal - private$current, tokens)
 }
 
 pb_message <- function(self, private, msg) {
+  assert_character(msg)
+  stopifnot(!private$finished)
+
   if (!private$supported) {
     cat(msg, sep = "\n", file = private$stream)
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,6 +49,10 @@ default_stream <- function(stream) {
   }
 }
 
+assert_character <- function(x) {
+  stopifnot(is.character(x),
+            length(x) > 0)
+}
 assert_character_scalar <- function(x) {
   stopifnot(is.character(x),
             length(x) == 1,

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,9 @@
 
 # 1.1.2.9000
 
+* Add a `message()` method to print a message line(s) above the progress bar,
+  @jimhester.
+
 * :elapsedfull token: elapsed time in hh:mm:ss format.
 
 # 1.1.2

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,8 @@
 
 # 1.1.2.9000
 
+* Outputs greater than the bar width are automatically trimmed, @jimhester.
+
 * Add a `message()` method to print a message line(s) above the progress bar,
   @jimhester.
 

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -387,3 +387,36 @@ test_that("very quick loops, only the nothing is shown", {
   expect_equal(out, sout)
 
 })
+
+
+test_that("message works", {
+
+  out <- get_output({
+    pb <- progress_bar$new(stream = stdout(), force = TRUE,
+                           show_after = 0, width = 20)
+    for (i in 1:4) {
+      if (i %% 2 == 0) {
+        pb$message(as.character(i))
+      }
+      pb$tick(25)
+    }
+  })
+
+  sout <- win_newline(
+    "\r[===----------]  25%",
+    "\r                    ",
+    "\r2\n",
+    "[===----------]  25%",
+    "\r[======-------]  50%",
+    "\r[==========---]  75%",
+    "\r                    ",
+    "\r4\n",
+    "[==========---]  75%",
+    "\r[=============] 100%",
+    "\r                    ",
+    "\r"
+  )
+
+  expect_equal(out, sout)
+
+})


### PR DESCRIPTION
I don't know if you want to have this be an option, I did not do so because it didn't seem like a good idea to allow more than the width inputs.

This includes #50, I can rebase once that is merged.