### PR TITLE
Make finished a public variable

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,6 +1,9 @@
 
 # 1.1.2.9000
 
+* Add `finished` variable, which can be queried to see if a progress bar is
+  finished. @jimhester.
+
 * Add a `terminate()` method, which can be called to explicitly remove the
   progress bar, @jimhester.
 

--- a/man/progress_bar.Rd
+++ b/man/progress_bar.Rd
@@ -49,6 +49,8 @@ Three functions can update a progress bar. \code{progress_bar$tick()}
 increases the number of ticks by one (or another specified value).
 \code{progress_bar$update()} sets a given ratio and
 \code{progress_bar$terminate()} removes the progress bar.
+\code{progress_bar$finished} can be used to see if the progress bar has
+finished.
 
 The progress bar is displayed after the first `tick` command.
 This might not be desirable for long computations, because


### PR DESCRIPTION
This allows users to see if a progress bar is finished before trying to
use `tick()` or `message()`, which is now an error on finished bars.