### PR TITLE
Add detection of RKWard running interactive session.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -39,9 +39,19 @@ r_app_stdx <- function(stream) {
     (is_stdout(stream) || is_stderr(stream))
 }
 
+is_rkward <- function() {
+    "rkward" %in% (.packages())
+}
+
+rkward_stdx <- function(stream) {
+  interactive() &&
+    is_rkward() &&
+    (is_stdout(stream) || is_stderr(stream))
+}
+
 is_supported <- function(stream) {
   is_option_enabled() &&
-    (isatty(stream) || r_studio_stdx(stream) || r_app_stdx(stream))
+    (isatty(stream) || r_studio_stdx(stream) || r_app_stdx(stream)) || rkward_stdx(stream)
 }
 
 is_option_enabled <- function() {

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,7 +51,7 @@ rkward_stdx <- function(stream) {
 
 is_supported <- function(stream) {
   is_option_enabled() &&
-    (isatty(stream) || r_studio_stdx(stream) || r_app_stdx(stream)) || rkward_stdx(stream)
+    (isatty(stream) || r_studio_stdx(stream) || r_app_stdx(stream) || rkward_stdx(stream))
 }
 
 is_option_enabled <- function() {


### PR DESCRIPTION
Tested and working on RKWard 0.7.0b.

The principle is that RKWard is loading its own package named "rkward" when it starts, so if the package is loaded, it means that R has been loaded by RKWard.

Let me know if I misunderstood how the code works.