### PR TITLE
Fix two issues with progress 1.2.1

### DIFF
--- a/inst/include/RProgress.h
+++ b/inst/include/RProgress.h
@@ -52,7 +52,7 @@ class RProgress {
     first(true), format(format), total(total), current(0), count(0),
     width(width), cursor_char(cursor_char), complete_char(complete_char),
     incomplete_char(incomplete_char), clear(clear), show_after(show_after),
-    last_draw(""), start(0), toupdate(false), complete(false) {
+    last_draw(""), start(0), toupdate(false), complete(false), reverse(false) {
 
     supported = is_supported();
     use_stderr = default_stderr();
@@ -69,7 +69,7 @@ class RProgress {
     first(true), format(format), total(total), current(0), count(0),
     width(width), cursor_char(&complete_char), complete_char(&complete_char),
     incomplete_char(&incomplete_char), clear(clear), show_after(show_after),
-    last_draw(""), start(0), toupdate(false), complete(false) {
+    last_draw(""), start(0), toupdate(false), complete(false), reverse(false) {
 
     supported = is_supported();
     use_stderr = default_stderr();

--- a/inst/include/RProgress.h
+++ b/inst/include/RProgress.h
@@ -67,8 +67,8 @@ class RProgress {
        double show_after = 0.2) :
 
     first(true), format(format), total(total), current(0), count(0),
-    width(width), cursor_char(&complete_char), complete_char(&complete_char),
-    incomplete_char(&incomplete_char), clear(clear), show_after(show_after),
+    width(width), cursor_char(1, complete_char), complete_char(1, complete_char),
+    incomplete_char(1, incomplete_char), clear(clear), show_after(show_after),
     last_draw(""), start(0), toupdate(false), complete(false), reverse(false) {
 
     supported = is_supported();


### PR DESCRIPTION
These are both my fault (sorry). The previous code did not initialize the reverse variable, so depending on the whims of the memory it could go forwards or reverse.

Also the way we were initializing the strings with characters was not safe, as if the character was a temporary it would be gone before the string was constructed.

I don't think we need an immediate release for these things, at least for vroom I can work around both issues. But we should plan one in the nearish future. 