### PR TITLE
fix: check that ratio is not NaN

### DIFF
--- a/R/progress.R
+++ b/R/progress.R
@@ -318,6 +318,7 @@ pb_tick <- function(self, private, len, tokens) {
 
 pb_ratio <- function(self, private) {
   ratio <- (private$current / private$total)
+  if (is.nan(ratio)) { ratio <- 0 }
   ratio <- max(ratio, 0)
   ratio <- min(ratio, 1)
   ratio


### PR DESCRIPTION
When both the current and total is set to 0, the division produces a
NaN which propagates through min/max operations and can't be used as a
boolean condition in an if, crashing the program with:

  Error in if (percent == 100) { : missing value where TRUE/FALSE needed